### PR TITLE
페이지 캐싱

### DIFF
--- a/src/app/(with-searchbar)/layout.tsx
+++ b/src/app/(with-searchbar)/layout.tsx
@@ -4,6 +4,7 @@ import Searchbar from "@/components/searchbar";
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div>
+      <div>{new Date().toLocaleString()}</div>
       <Suspense fallback={<div>Loading...</div>}>
         <Searchbar />
       </Suspense>

--- a/src/app/(with-searchbar)/layout.tsx
+++ b/src/app/(with-searchbar)/layout.tsx
@@ -1,10 +1,12 @@
-import { ReactNode } from "react";
+import { ReactNode, Suspense } from "react";
 import Searchbar from "@/components/searchbar";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div>
-      <Searchbar />
+      <Suspense fallback={<div>Loading...</div>}>
+        <Searchbar />
+      </Suspense>
       {children}
     </div>
   );

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -25,7 +25,7 @@ async function RecoBooks() {
 async function AllBooks() {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`,
-    { cache: "no-store" }
+    { cache: "force-cache" }
   );
   if (!response.ok) {
     return <div>오류가 발생했습니다...</div>;

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -2,6 +2,13 @@ import style from "./page.module.css";
 import BookItem from "@/components/book-item";
 import { BookData } from "@/types";
 
+// 특정 페이지의 유형을 강제로 Static, Dynamic 페이지로 설정
+// export const dynamic = "force-dynamic";
+// 1. auto : 기본값, 아무것도 강제하지 않음 (생략가능)
+// 2. force-dynamic : 페이지를 강제로 Dynamic 페이지로 설정
+// 3. force-static : 페이지를 강제로 Static 페이지로 설정
+// 4. error : 페이지를 강제로 Static 페이지 설정
+
 // 추천 도서
 async function RecoBooks() {
   const response = await fetch(

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -14,7 +14,8 @@ export default async function Page({
       (
         await searchParams
       ).q
-    }`
+    }`,
+    { cache: "force-cache" }
   );
   if (!response.ok) {
     return <div>오류가 발생했습니다</div>;

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1,4 +1,14 @@
+import { notFound } from "next/navigation";
 import style from "./page.module.css";
+
+// generateStaticParams()로 생성된 페이지 외에 모든 페이지는 다 404페이로 리다이렉트 처리
+// export const dynamicParams = false;
+
+// 동적 경로를 같은 페이지를 Static Page로 만들기 위한 parmas를 정적으로 생성하는 함수
+// Page Router의 getStaticPath 와 동일한 역할을 한다.
+export function generateStaticParams() {
+  return [{ id: "1" }, { id: "2" }, { id: "3" }];
+}
 
 export default async function Page({
   params,
@@ -10,6 +20,9 @@ export default async function Page({
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book/${(await params).id}`
   );
   if (!response.ok) {
+    if (response.status === 404) {
+      notFound();
+    }
     return <div>오류가 발생했습니다...</div>;
   }
   const book = await response.json();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,8 @@ import { BookData } from "@/types";
 
 async function Footer() {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`,
+    { cache: "force-cache" }
   );
   if (!response.ok) {
     return <footer>제작 @winterlood</footer>;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import style from "./layout.module.css";
 import { BookData } from "@/types";
 
-export async function Footer() {
+async function Footer() {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>404: NotFound</div>;
+}


### PR DESCRIPTION
## 1️⃣ 풀 라우트 캐시
- Next 서버 측에서 **빌드 타임**에 **특정 페이지의 렌더링 결과를 캐싱**하는 기능으로 **Static Page**에만 적용이 가능하다.
    - 브라우저의 요청을 받으면 풀 라우트 캐시에 있는 페이지를 제공하기 때문에 빠르게 페이지를 제공할 수 있다.
- 페이지를 구성하는 컴포넌트들 중 하나라도 Data Fetch 가 revalidate 설정이 되어 있다면, 데이터 캐시뿐만 아니라 풀 라우트 캐시도 업데이트가 된다.

### Dynamic Page로 설정되는 기준
- 특정 페이지가 **접속 요청을 받을 때 마다 매번 변**화가 생기거나, 데이터가 달라질 경우
    - **캐시 되지 않는 Data Fetching** 을 사용하는 경우
    - **동적 함수(쿠키, 헤더, 쿼리스트링)** 을 사용하는 컴포넌트가 있을 때

### Static Page로 설정되는 기준
- Dynamic Page가 아니면 모두 Static Page가 된다.(default)
    - 동적 함수를 사용하지 않으면서, 데이터 캐시를 하고 있는 페이지

## 2️⃣ 라우트 세그먼트 옵션
> ☝🏻 잦은 사용은 권장되지 않는다. 꼭 필요한 경우에만 사용하도록!!

- 특정 페이지에서 **약속된 이름의 변수**를 선언하고 값을 설정해서 내보냄으로서 **페이지의 설정을 강제로 조정**할 수 있는 기능이다.

### `export const dynamicParams = false;` 
- generateStaticParams()로 생성된 페이지 외에 모든 페이지는 다 404페이로 리다이렉트 처리한다.

### `export const dynamic = “” ;`
- 특정 페이지의 유형을 강제로 Static, Dynamic 페이지로 설정
    1. `auto` : 기본값, 아무것도 강제하지 않음 (생략가능)
    2. `force-dynamic` : 페이지를 강제로 Dynamic 페이지로 설정
    3. `force-static` : 페이지를 강제로 Static 페이지로 설정
        1. Dynamic 페이지를 force-static으로 설정하면 동적 함수(searchParmas)의 값이 무조건 빈 값으로 설정되어 페이지가 정상적으로 작동하지 않을 수 있다. 
    4. `error` : 페이지를 강제로 Static 페이지 설정 
        1. force-static과는 다르게 Static 페이지를 설정할 수 없는 페이지라면 빌드 오류를 발생시킨다.

## 3️⃣ 클라이언트 라우터 캐시
- 브라우저에 저장된다.
- 페이지 이동을 효율적으로 진행하기 위해 페이지의 일부 데이터를 보관한다.
    - 공통 **레이아웃**(`layout.tsx`)에 해당하는 페이지(RSC Payload)의 데이터만 클라이언트 라우터 캐시에 저장한다.
- 다른 페이지로 이동시, 중복된 **레이아웃**(`layout.tsx`)은 다시 서버에서 불러오지 않고, 클라이언트 라우터에서 가져오도록 한다.
- 새로 고침을 하면 리셋된다.
- 따로 설정해줄 것 없이, **Next.js에서 자동으로 적용**된다.