### PR TITLE
스트리밍&에러 핸들링

### DIFF
--- a/src/app/(with-searchbar)/error.tsx
+++ b/src/app/(with-searchbar)/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { startTransition, useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => console.error(error.message), [error]);
+
+  return (
+    <div>
+      <h3>오류가 발생했습니다.</h3>
+      <button
+        onClick={() => {
+          startTransition(() => {
+            router.refresh();
+            reset();
+          });
+        }}
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -1,9 +1,13 @@
-import style from "./page.module.css";
+import { Suspense } from "react";
+
 import BookItem from "@/components/book-item";
 import { BookData } from "@/types";
+import { delay } from "@/util/delay";
+
+import style from "./page.module.css";
 
 // 특정 페이지의 유형을 강제로 Static, Dynamic 페이지로 설정
-// export const dynamic = "force-dynamic";
+export const dynamic = "force-dynamic";
 // 1. auto : 기본값, 아무것도 강제하지 않음 (생략가능)
 // 2. force-dynamic : 페이지를 강제로 Dynamic 페이지로 설정
 // 3. force-static : 페이지를 강제로 Static 페이지로 설정
@@ -11,6 +15,8 @@ import { BookData } from "@/types";
 
 // 추천 도서
 async function RecoBooks() {
+  await delay(3000);
+
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book/random`,
     { next: { revalidate: 3 } }
@@ -30,6 +36,8 @@ async function RecoBooks() {
 }
 // 모든 도서
 async function AllBooks() {
+  await delay(1500);
+
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`,
     { cache: "force-cache" }
@@ -53,11 +61,15 @@ export default function Home() {
     <div className={style.container}>
       <section>
         <h3>지금 추천하는 도서</h3>
-        <RecoBooks />
+        <Suspense fallback={<div>도서를 불러오는 중입니다...</div>}>
+          <RecoBooks />
+        </Suspense>
       </section>
       <section>
         <h3>등록된 모든 도서</h3>
-        <AllBooks />
+        <Suspense fallback={<div>도서를 불러오는 중입니다...</div>}>
+          <AllBooks />
+        </Suspense>
       </section>
     </div>
   );

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -5,6 +5,8 @@ import { BookData } from "@/types";
 import { delay } from "@/util/delay";
 
 import style from "./page.module.css";
+import BookItemSkeleton from "@/components/skeleton/book-item-skeleton";
+import BookListSkeleton from "@/components/skeleton/book-list-skeleton";
 
 // 특정 페이지의 유형을 강제로 Static, Dynamic 페이지로 설정
 export const dynamic = "force-dynamic";
@@ -61,13 +63,13 @@ export default function Home() {
     <div className={style.container}>
       <section>
         <h3>지금 추천하는 도서</h3>
-        <Suspense fallback={<div>도서를 불러오는 중입니다...</div>}>
+        <Suspense fallback={<BookListSkeleton count={3} />}>
           <RecoBooks />
         </Suspense>
       </section>
       <section>
         <h3>등록된 모든 도서</h3>
-        <Suspense fallback={<div>도서를 불러오는 중입니다...</div>}>
+        <Suspense fallback={<BookListSkeleton count={10} />}>
           <AllBooks />
         </Suspense>
       </section>

--- a/src/app/(with-searchbar)/search/error.tsx
+++ b/src/app/(with-searchbar)/search/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { startTransition, useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => console.error(error.message), [error]);
+
+  return (
+    <div>
+      <h3>검색 결과에 대한 오류가 발생했습니다.</h3>
+      <button
+        onClick={() => {
+          startTransition(() => {
+            router.refresh();
+            reset();
+          });
+        }}
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/app/(with-searchbar)/search/loading.tsx
+++ b/src/app/(with-searchbar)/search/loading.tsx
@@ -1,3 +1,0 @@
-export default function Loading() {
-  return <div>Loading...</div>;
-}

--- a/src/app/(with-searchbar)/search/loading.tsx
+++ b/src/app/(with-searchbar)/search/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>;
+}

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -1,5 +1,6 @@
 import BookItem from "@/components/book-item";
 import { BookData } from "@/types";
+import { delay } from "@/util/delay";
 
 export default async function Page({
   searchParams,
@@ -8,6 +9,7 @@ export default async function Page({
     q?: string;
   }>;
 }) {
+  await delay(1500);
   // 검색 도서
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book/search?q=${

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -1,22 +1,14 @@
+import { Suspense } from "react";
+
 import BookItem from "@/components/book-item";
 import { BookData } from "@/types";
 import { delay } from "@/util/delay";
 
-export default async function Page({
-  searchParams,
-}: {
-  searchParams: Promise<{
-    q?: string;
-  }>;
-}) {
+async function SearchResult({ q }: { q: string }) {
   await delay(1500);
-  // 검색 도서
+
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book/search?q=${
-      (
-        await searchParams
-      ).q
-    }`,
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book/search?q=${q}`,
     { cache: "force-cache" }
   );
   if (!response.ok) {
@@ -30,5 +22,17 @@ export default async function Page({
         <BookItem key={book.id} {...book} />
       ))}
     </div>
+  );
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: { q?: string };
+}) {
+  return (
+    <Suspense key={searchParams.q || ""} fallback={<div>Loading...</div>}>
+      <SearchResult q={searchParams.q || ""} />
+    </Suspense>
   );
 }

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import BookItem from "@/components/book-item";
 import { BookData } from "@/types";
 import { delay } from "@/util/delay";
+import BookListSkeleton from "@/components/skeleton/book-list-skeleton";
 
 async function SearchResult({ q }: { q: string }) {
   await delay(1500);
@@ -31,7 +32,10 @@ export default function Page({
   searchParams: { q?: string };
 }) {
   return (
-    <Suspense key={searchParams.q || ""} fallback={<div>Loading...</div>}>
+    <Suspense
+      key={searchParams.q || ""}
+      fallback={<BookListSkeleton count={3} />}
+    >
       <SearchResult q={searchParams.q || ""} />
     </Suspense>
   );

--- a/src/app/book/[id]/error.tsx
+++ b/src/app/book/[id]/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { startTransition, useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => console.error(error.message), [error]);
+
+  return (
+    <div>
+      <h3>오류가 발생했습니다.</h3>
+      <button
+        onClick={() => {
+          startTransition(() => {
+            router.refresh();
+            reset();
+          });
+        }}
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,8 @@ import { BookData } from "@/types";
 
 async function Footer() {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`,
-    { cache: "force-cache" }
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/book`
+    // { cache: "force-cache" }
   );
   if (!response.ok) {
     return <footer>제작 @winterlood</footer>;
@@ -35,7 +35,7 @@ export default function RootLayout({
             <Link href={"/"}>📚 ONEBITE BOOKS</Link>
           </header>
           <main>{children}</main>
-          <Footer />
+          {/* <Footer /> */}
         </div>
       </body>
     </html>

--- a/src/components/skeleton/book-item-skeleton.module.css
+++ b/src/components/skeleton/book-item-skeleton.module.css
@@ -1,0 +1,24 @@
+.container {
+  display: flex;
+  gap: 15px;
+  padding: 20px 10px;
+  border-bottom: 1px solid rgb(220, 220, 220);
+}
+
+.cover_img {
+  width: 80px;
+  height: 105px;
+  background-color: rgb(230, 230, 230);
+}
+
+.info_container {
+  flex: 1;
+}
+
+.title,
+.subtitle,
+.author {
+  width: 100%;
+  height: 20px;
+  background-color: rgba(230, 230, 230);
+}

--- a/src/components/skeleton/book-item-skeleton.tsx
+++ b/src/components/skeleton/book-item-skeleton.tsx
@@ -1,0 +1,15 @@
+import style from "./book-item-skeleton.module.css";
+
+export default function BookItemSkeleton() {
+  return (
+    <div className={style.container}>
+      <div className={style.cover_img}></div>
+      <div className={style.info_container}>
+        <div className={style.title}></div>
+        <div className={style.subtitle}></div>
+        <br />
+        <div className={style.author}></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/skeleton/book-list-skeleton.tsx
+++ b/src/components/skeleton/book-list-skeleton.tsx
@@ -1,0 +1,9 @@
+import BookItemSkeleton from "./book-item-skeleton";
+
+export default function BookListSkeleton({ count }: { count: number }) {
+  return new Array(count)
+    .fill(0)
+    .map((_, index) => (
+      <BookItemSkeleton key={`book-item-skeleton-${index}`} />
+    ));
+}

--- a/src/util/delay.ts
+++ b/src/util/delay.ts
@@ -1,0 +1,11 @@
+/**
+ * 딜레이 함수
+ * @param ms 딜레이 시간
+ */
+export async function delay(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve("");
+    }, ms);
+  });
+}


### PR DESCRIPTION
## 1️⃣ 스트리밍
### 스트리밍이란
- 서버에서 클라이언트로 매우 큰 용량의 데이터를 보내줄 때, 데이터를 잘게 쪼개서 보내주는 것을 말한다.
- 데이터 전체가 다 전달되지 않아도 먼저 전달된 데이터를 우선적으로 렌더링하기 때문에 사용자 입장에서 빠르게 화면을 볼 수 있게 된다.

### Next.js의 스트리밍
- 스트리밍을 통해 일단 뭐라도 빠르게 보여줄 수 있게된다.
    → 오래 걸리는 컴포넌트의 렌더링을 사용자가 좀 더 좋은 환경에서 기다릴 수 있도록 빨리 렌더링 할 수 있는 컴포넌트를 **밑반찬 처럼 내주는 것**이라고 생각하면 된다!
- 먼저 렌더링된 컴포넌트(동기 작업)를 보여주고, 느리게 렌더링 되는 컴포넌트(비동기 작업)는 대체 UI를 보여주면 된다.
- Dynamic Page에 자주 사용된다.

### 페이지 스트리밍
- 특정 페이지 컴포넌트 스트리밍 설정 방법 해당 컴포넌트 페이지와 동일한 위치에 `loading.tsx` 생성
    → 해당 컴포넌트가 로딩중일 때는 loading.tsx에 작업한 로딩 컴포넌트가 대신 보여지게 된다.
 
#### 🚨 주의사항 
1. `loading.tsx` 는 현재 경로에 있는 page 컴포넌트 뿐만 아니라 마치 layout 처럼 **해당 경로 아래에 있는 모든 비동기 page 컴포넌트** 를 스트리밍 되도록 만든다.
2. 스트리밍은 async가 적용된 **비동기 컴포넌트 페이지** 에만 적용된다.
3. `loading.tsx` 는 무조건 page 컴포넌트에만 스트리밍을 적용할 수 있다. 따라서, layout이나 다른 컴포넌트에는 적용되지 않는다.
4.  `loading.tsx` 로 설정된 스트리밍은 브라우저에서 쿼리 스트링이 변경될 때에는 트리거링 되지 않는다. (경로 자체가 변경된 것이 아니라, 쿼리 스티링의 값만 바뀐 경우에는 적용X)

### 컴포넌트 스트리밍
- react의 **Suspense 컴포넌트**를 활용한다.
    - Suspense 컴포넌트의 fallback 속성에 대체 UI를 넘겨준다.
- 쿼리 스트링이 변경되었을 경우에도 대체 UI를 보여줄 수 있다.
    - Suspense 컴포넌트의 key 속성에 어떤 값이 변경될 때마다 UI를 보여줄 것인지 넣어주면 된다.

> 기본적으로 Suspense 컴포넌트는 최초로 한번 내부 컴포넌트 로딩이 완료된 이후로는 내부의 콘텐츠가 변경되어도 로딩 상태로 돌아가지 않는다. 따라서 key 값을 동적으로 설정하면 key값이 변할 때마다 새로운 컴포넌트로 인식하게 하여 매번 로딩 상태를 보여주게 된다.

> skeleton UI 참고 [react-loading-skeleton](https://www.npmjs.com/package/react-loading-skeleton) 

## 2️⃣ 에러 핸들링 
- 특정 경로에서 발생한 모든 오류를 한꺼번에 처리할 수 있다.
    - 에러를 처리할 파일 생성, page 컴포넌트와 같은 위치에 `error.tsx` 생성
    - “use client” 를 선언하는 이유 : 오류는 서버,클라이언트를 막론하고 발생할 수 있기 때문에 모두 대응하기 위함이다.
- error.tsx 속성
    - `error`
        - 에러 메세지를 출력하고 싶다면 props로 error를 전달 받아서 출력하면 된다. 이는 Next.js에서 자동으로 제공된다.
    - `reset`
        - 에러 발생을 복구하기 위해서 컴포넌트를 다시 실행시키는 함수이다. (에러 상태를 초기화, 컴포넌트들을 다시 렌더링)
        - 클라이언트 측에서 현재 서버로부터 전달받은 데이터를 이용해서 화면을 렌더링 하는 기능이다.
        즉, 서버 컴포넌트는 다시 실행하지는 않는다.
            - `window.location.reload()` : 강제 새로 고침 실행 (←클라이언트에 저장된 상태 값들도 함께 날라갈 수 있기 때문에 권장X)
            - `router.refresh()` : 현재 페이지에 필요한 서버 컴포넌트들을 다시 불러옴
                -  `asyn-await`는 사용할 수 없다. (why? router.refersh()에서 적용되지 않는다고 알려주고 있음)
                - `startTransition` : react18 부터 도입, 콜백 함수를 인수로 받아 콜백 함수 안에 있는 UI를 변경시키는 작업을 일괄적으로 처리함
- error.tsx 위치
    - 동일 경로, 하위 경로에 적용된다.
    - 만약, 특정 페이지에 대한 에러 페이지가 필요하다면 해당 페이지 동일한 경로에 error.tsx를 만들어주면 된다.



