### PR TITLE
패럴렐 라우트

### DIFF
--- a/src/app/parallel/@feed/page.tsx
+++ b/src/app/parallel/@feed/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@feed</div>;
+}

--- a/src/app/parallel/@feed/setting/page.tsx
+++ b/src/app/parallel/@feed/setting/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@feed/setting</div>;
+}

--- a/src/app/parallel/@sidebar/default.tsx
+++ b/src/app/parallel/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>@sidebar/default</div>;
+}

--- a/src/app/parallel/@sidebar/page.tsx
+++ b/src/app/parallel/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@sidebar</div>;
+}

--- a/src/app/parallel/default.tsx
+++ b/src/app/parallel/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>/parallel/default</div>;
+}

--- a/src/app/parallel/layout.tsx
+++ b/src/app/parallel/layout.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function Layout({
+  children,
+  sidebar,
+  feed,
+}: {
+  children: React.ReactNode;
+  sidebar: React.ReactNode;
+  feed: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div>
+        <Link href={"/parallel"}>parallel</Link>
+        &nbsp;
+        <Link href={"/parallel/setting"}>parallel/setting</Link>
+      </div>
+
+      <br />
+      {feed}
+      {sidebar}
+      {children}
+    </div>
+  );
+}

--- a/src/app/parallel/page.tsx
+++ b/src/app/parallel/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>/parallel</div>;
+}


### PR DESCRIPTION
## 1️⃣ 패럴렐 라우트
### 병렬 라우트
- 하나의 화면 안에 **여러 페이지 컴포넌트(`page.tsx`)를** 한번에 렌더링 시켜주는 패턴이다.
- 소셜 미디어, 어드민 대시보드 등 복잡한 구조에 사용된다.

### Slot(슬롯)
- 병렬로 렌더링 될 페이지 **컴포넌트를 보관**하는 폴더 역할을 한다.
- 원하는 페이지 폴더 아래에 **`@` 를 붙여서 폴더**를 만들어 준다. ex)`@sidebar`
    - 이때, 생성된 슬롯은 라우트 그룹처럼  URL 경로에는 아무런 영향을 주지 않는다.
- **부모 컴포넌트(`layout.tsx`)에** **자동으로 props(`ReactNode 타입`)로 전달**된다.
- 개수 제한이 없다. 하나의 페이지 디렉토리 안에 여러 개의 슬롯을 만들 수 있다.
- 슬롯 안에서 새로운 페이지를 추가할 수 있다.
    
#### ❗주의 사항 
1. `<Link/>` 를 통해 진입한 경우
   - `<Link/>`를 클릭하면 Next.js의 **클라이언트 라우팅**이 작동하게 되는데 이때, Next.js는 **기존 페이지에서 새로운 슬롯(`parallel/@feed/setting/page.tsx`)을 동적으로 불러와서 렌더링**하게 된다.
   - 즉, 현재 **`layout.tsx`가 유지된 상태에서 페렐렐 라우트 내부만 업데이트** 되기 때문에 정상적으로 동작한다.
2.  초기 진입한 경우
    - Next.js는 해당 페이지가 독립적인 페이지인지를 확인하는데, 슬롯 안에 등록된 페이지는 직접 페이지로 등록하지 않기 때문에 존재하지 않는 경로라고 판단한다.
    - 즉, 페럴dlfkgm렐 라우트 내부 페이지들은 기본적으로 단독으로 접근할 수 없고 반드시 상위 **`layout.tsx`** 가 존재해야 정상적으로 렌더링 된다.
3. 해결 방법
   - `default.tsx`는 **페럴렐 라우트가 비어 있을 때 기본적으로 보여줄 페이지**를 지정하는 역할을 한다.

> **참고 사항** 
패럴렐 라우트의 경우 개발 모드에서 버그가 발생하고 있기 때문에 만약 패럴렐 라우트 적용이 안된다면, 
`.next` 삭제 후 개발 서버를 재가동한다.
