### PR TITLE
페이지 라우팅 경로 자동화 스크립트

### DIFF
--- a/apps/lab/createRoutes.js
+++ b/apps/lab/createRoutes.js
@@ -1,0 +1,66 @@
+import { readdirSync, statSync, writeFileSync } from "fs";
+import { join, relative } from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// 기준 디렉토리 설정
+const currentDir = __dirname;
+const appDirectory = join(currentDir, "src", "app");
+const constantFilePath = join(currentDir, "src", "lib", "routes.ts");
+
+// 그룹 라우팅 제거, 다이나믹 라우팅 처리
+function cleanPath(filePath) {
+  const cleanedPath = relative(appDirectory, filePath)
+    .replace(/\/page\.tsx$/, "") // page.tsx 제거
+    .replace(/\(.*?\)/g, "") // 그룹 라우팅 제거
+    .replace(/\[.*?\]/g, ":param") // 다이나믹 라우팅 처리 (예: [id] → :param)
+    .replace(/\/+/g, "/"); // 중복된 슬래시 제거
+
+  return cleanedPath.startsWith("/") ? cleanedPath : "/" + cleanedPath;
+}
+
+// 상수 이름 생성 (특수문자 제거, 대문자화)
+function toConstName(path) {
+  const constName = path
+    .toUpperCase()
+    .replace(/\//g, "_")
+    .replace(/[^A-Z0-9_]/g, "") // 문자, 숫자, 언더스코어 외 제거
+    .replace(/^_+|_+$/g, ""); // 앞뒤 언더스코어 제거
+
+  return `${constName}_PATHNAME`;
+}
+
+// 재귀적으로 모든 page.tsx 파일 탐색
+function findPageFiles(dir) {
+  const entries = readdirSync(dir);
+  let pageFiles = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      pageFiles = pageFiles.concat(findPageFiles(fullPath));
+    } else if (entry === "page.tsx") {
+      pageFiles.push(fullPath);
+    }
+  }
+
+  return pageFiles;
+}
+
+// 실행 로직
+const pageFiles = findPageFiles(appDirectory);
+
+const routes = pageFiles.map((filePath) => {
+  const path = cleanPath(filePath);
+  const constName = toConstName(path);
+  return `export const ${constName} = "${path}";`;
+});
+
+writeFileSync(constantFilePath, routes.join("\n") + "\n", "utf-8");
+
+console.log(`✅ routes.ts 파일이 생성되었습니다: ${constantFilePath}`);

--- a/apps/lab/package.json
+++ b/apps/lab/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--inspect' next dev",
+    "create-routes": "node ./createRoutes.js",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/lab/src/lib/routes.ts
+++ b/apps/lab/src/lib/routes.ts
@@ -1,0 +1,4 @@
+export const _PATHNAME = "/";
+export const OOM_EXAMPLE_PATHNAME = "/oom/example";
+export const OOM_EXAMPLE2_PATHNAME = "/oom/example2";
+export const OOM_PATHNAME = "/oom";


### PR DESCRIPTION
## 📝 작업 내용
### 문제 
- `router.push("")` 혹은  `<Link href="" />` 를 사용할 때마다 하드코딩으로 경로를 작성해야함
- 실수로 경로를 잘못 입력할 수도 있고, 만약 경로가 바뀌게 된다면 해당 경로를 하나하나 다 바꿔 줘야함 

### 액션
-  `src/app` 디렉토리 기준으로 재귀적으로 탐색하여 각 디렉토리의 `page.tsx` 파일의 경로를 찾는 스크립트를 작성함
   - 결과적으로 실제 라우트 경로 추출
   - 변환된 경로를 기반으로 상수를 자동 생성
- Next.js의 그룹 라우팅 `(group)`, 다이나믹 라우팅 `[param]` 등은 실제 경로에 반영되지 않기 때문에 이를 제거 또는 변환하는 로직 추가
- 생성된 상수는 `src/lib/routes.ts`에 저장되어 import 하여 사용 

```
export const BLOG_DASHBOARD_PATHNAME = "/blog/dashboard";
```

## 🎉 결과
- `package.json`에 `"create-routes": "node ./createRoutes.js"` 명령어 등록 → 실행 시 자동으로 `routes.ts` 생성
- 모든 라우트 경로를 하드코딩 없이 상수로 관리할 수 있어 유지 보수성이 크게 향상됨
- 컴포넌트에서 사용할 때 오타 방지 및 경로 변경 시에도 일괄 수정 가능

## 🧠 추가 고려사항
- [ ] 패럴렐 라우팅 (`@folder`)은 아직 처리되지 않음 
- [ ] 협업 시 라우트 파일 충돌 가능성 있음 
- [ ] 다양한 케이스에 대한 테스트 필요 -> 제대로 스크립트가 작동하는지?
 