### PR TITLE
패럴렐 라우트를 사용해서 모달 만들기

### DIFF
--- a/apps/lab/src/app/dashboard/@modal/all/page.tsx
+++ b/apps/lab/src/app/dashboard/@modal/all/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function ModalAll() {
+  const router = useRouter();
+
+  const handleClickToClose = () => {
+    router.back();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white w-[200px] h-[200px] flex flex-col gap-4 p-4 rounded-lg">
+        <h1>All</h1>
+        <div className="flex flex-col gap-4">
+          <button onClick={handleClickToClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/lab/src/app/dashboard/@modal/default.tsx
+++ b/apps/lab/src/app/dashboard/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null;
+}

--- a/apps/lab/src/app/dashboard/layout.tsx
+++ b/apps/lab/src/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+export default function DashboardLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <div className="dashboard-layout relative">
+      {children}
+      {modal}
+    </div>
+  );
+}

--- a/apps/lab/src/app/dashboard/page.tsx
+++ b/apps/lab/src/app/dashboard/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function DashboardPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <p className="mb-4">This is the dashboard page.</p>
+
+      <div className="flex gap-4">
+        <Link href="/dashboard/all">
+          <button>Open</button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 작업 내용
### 문제
기존에는 모달 상태를 전역 또는 지역 상태로 관리하면서
1. 상태 관리 코드의 복잡도가 높아진다.
2. android 와 같은 웹뷰 환경에서 물리 백버튼을 직접 제어해야하는데 이로 인해 유지보수가 어려워지는 문제가 있다.

### 액션
Next.js의 패럴렐 라우트 기능을 활용하여 모달을 라우팅 기반으로 구현했다.
- 모달 오픈 시 `router.push()` 또는 `<Link />` 를 통해  URL을 변경한다.
- URL 변경에 따라 해당 슬롯에 모달이 렌더링되도록 구성한다.
- 브라우저/웹뷰의 물리 백버튼 또는 `router.back()` 사용 시 모달이 자연스럽게 닫히도록 동작한다.

## 🎉 결과

https://github.com/user-attachments/assets/0e9e5896-20f7-4b3e-bada-a651736f1ff9

- 상태 관리 없이도 모달 UI를 제어할 수 있고 코드 간결성 및 유지보수성이 향상된다.
- 물리 백버튼을 제어하기 위한 별도의 코드가 필요없다.

## 🧠 추가 고려사항
- Soft Navigation 기반이기 때문에, 새로고침 또는 URL 직접 접근 시 모달 라우트가 누락되어 접근이 불가능하다.
- 중첩 모달이 필요한 경우, 추가 패럴렐 슬롯 정의 필요하다.