### PR TITLE
template.tsx를 활용한 페이지 전환 애니메이션

### DIFF
--- a/apps/lab/package.json
+++ b/apps/lab/package.json
@@ -10,19 +10,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "framer-motion": "^12.16.0",
+    "next": "15.2.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.2.4"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/apps/lab/src/app/(mobile)/layout.tsx
+++ b/apps/lab/src/app/(mobile)/layout.tsx
@@ -9,7 +9,7 @@ export default function RootLayout({
 }>) {
   return (
     <>
-      <Header
+      {/* <Header
         left={
           <>
             <Link href="/">홈</Link>
@@ -23,7 +23,7 @@ export default function RootLayout({
             <Link href="/">마이</Link>
           </>
         }
-      />
+      /> */}
       {children}
       <NavigationBar />
     </>

--- a/apps/lab/src/app/layout.tsx
+++ b/apps/lab/src/app/layout.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+import { NavLinks } from "@/components/molecules/NavLinks";
+import AnimationProvider from "@/provider/AnimationProvider";
+import { RouterWrapperProvider } from "@/provider/RouterWrapperProvider";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -27,7 +31,12 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <RouterWrapperProvider>
+          <AnimationProvider>
+            <NavLinks />
+            <main> {children}</main>
+          </AnimationProvider>
+        </RouterWrapperProvider>
       </body>
     </html>
   );

--- a/apps/lab/src/app/template.tsx
+++ b/apps/lab/src/app/template.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React from "react";
+import { usePathname } from "next/navigation";
+
+import { motion } from "framer-motion";
+
+import {
+  NavigationDirection,
+  useRouterWrapper,
+} from "@/provider/RouterWrapperProvider";
+
+export default function Template({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { direction } = useRouterWrapper();
+
+  // const [cachedChildren, setCachedChildren] = useState<React.ReactNode | null>(
+  //   null
+  // );
+  // const previousPathRef = useRef<string | null>(null);
+
+  // useEffect(() => {
+  //   if (previousPathRef.current !== pathname) {
+  //     setCachedChildren(children); // 캐싱된 children 저장
+  //     previousPathRef.current = pathname;
+  //   }
+  // }, [pathname, children]);
+
+  return (
+    <div className="flex relative">
+      <motion.div
+        key={pathname}
+        custom={direction}
+        variants={{
+          enter: (direction: NavigationDirection) => ({
+            x: direction === "forward" ? "100vw" : "-100vw",
+          }),
+          center: {
+            x: 0,
+          },
+        }}
+        initial={"enter"}
+        animate={"center"}
+        transition={{ duration: 1, ease: "easeInOut" }}
+      >
+        {children}
+      </motion.div>
+
+      <motion.div
+        key={"prev cache page"}
+        custom={direction}
+        variants={{
+          center: {
+            x: 0,
+          },
+          exit: (direction: NavigationDirection) => ({
+            x: direction === "forward" ? "-100vw" : "100vw",
+          }),
+        }}
+        initial={"center"}
+        animate={"exit"}
+        transition={{ duration: 1, ease: "easeInOut" }}
+        style={{
+          position: "absolute",
+          width: "100vw",
+        }}
+      >
+        {"cached page"}
+      </motion.div>
+    </div>
+  );
+}

--- a/apps/lab/src/components/atoms/ExtendedLink.tsx
+++ b/apps/lab/src/components/atoms/ExtendedLink.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { useRouterWrapper } from "@/provider/RouterWrapperProvider";
+
+interface ExtendedLinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function ExtendedLink({
+  href,
+  children,
+  className,
+}: ExtendedLinkProps) {
+  const router = useRouterWrapper();
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    router.push(href);
+  };
+  return (
+    <Link className={`link ${className}`} onClick={onClick} href="#">
+      {children}
+    </Link>
+  );
+}

--- a/apps/lab/src/components/molecules/NavLinks.tsx
+++ b/apps/lab/src/components/molecules/NavLinks.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useRouterWrapper } from "@/provider/RouterWrapperProvider";
+import ExtendedLink from "@/components/atoms/ExtendedLink";
+
+export function NavLinks() {
+  const pathname = usePathname();
+  const router = useRouterWrapper();
+
+  return (
+    <nav className=" flex gap-4">
+      <button onClick={router.back}>{`<`}</button>
+      <ExtendedLink
+        className={`link ${pathname === "/oom" ? "active" : ""}`}
+        href="/oom"
+      >
+        OOM
+      </ExtendedLink>
+
+      <ExtendedLink
+        className={`link ${pathname === "/dashboard" ? "active" : ""}`}
+        href="/dashboard"
+      >
+        Dashboard
+      </ExtendedLink>
+    </nav>
+  );
+}

--- a/apps/lab/src/provider/AnimationProvider.tsx
+++ b/apps/lab/src/provider/AnimationProvider.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { AnimatePresence } from "framer-motion";
+
+export default function AnimationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [isFirstMounted, setIsFirstMounted] = useState(false);
+
+  useEffect(() => {
+    setIsFirstMounted(true);
+  }, []);
+
+  return (
+    <AnimatePresence initial={isFirstMounted}>
+      <div key={pathname}>{children}</div>
+    </AnimatePresence>
+  );
+}

--- a/apps/lab/src/provider/RouterWrapperProvider.tsx
+++ b/apps/lab/src/provider/RouterWrapperProvider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useState, useCallback, useContext } from "react";
+import { useRouter } from "next/navigation";
+
+export type NavigationDirection = "forward" | "backward";
+
+interface RouterWrapperContextType {
+  direction: NavigationDirection;
+  push: (url: string) => void;
+  back: () => void;
+}
+
+const RouterWrapperContext = createContext<RouterWrapperContextType | null>(
+  null
+);
+
+export function RouterWrapperProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [direction, setDirection] = useState<NavigationDirection>("forward");
+  const router = useRouter();
+
+  const push = useCallback(
+    (url: string) => {
+      setDirection("forward");
+      router.push(url);
+    },
+    [router]
+  );
+
+  const back = useCallback(() => {
+    setDirection("backward");
+    router.back();
+  }, [router]);
+
+  return (
+    <RouterWrapperContext.Provider value={{ direction, push, back }}>
+      {children}
+    </RouterWrapperContext.Provider>
+  );
+}
+
+export function useRouterWrapper() {
+  const context = useContext(RouterWrapperContext);
+  if (!context) {
+    throw new Error(
+      "useRouterWrapper must be used within a RouterWrapperProvider"
+    );
+  }
+  return context;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
     "apps/lab": {
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.16.0",
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -254,7 +255,6 @@
       }
     },
     "apps/onebite": {
-      "name": "app-router",
       "version": "0.1.0",
       "dependencies": {
         "@repo/ui": "*",
@@ -2529,10 +2529,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/app-router": {
-      "resolved": "apps/onebite",
-      "link": true
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -4448,6 +4444,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.16.0.tgz",
+      "integrity": "sha512-xryrmD4jSBQrS2IkMdcTmiS4aSKckbS7kLDCuhUn9110SQKG1w3zlq1RTqCblewg+ZYe+m3sdtzQA6cRwo5g8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.16.0",
+        "motion-utils": "^12.12.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -6293,6 +6316,21 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.16.0.tgz",
+      "integrity": "sha512-Z2nGwWrrdH4egLEtgYMCEN4V2qQt1qxlKy/uV7w691ztyA41Q5Rbn0KNGbsNVDZr9E8PD2IOQ3hSccRnB6xWzw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.12.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6760,6 +6798,10 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onebite": {
+      "resolved": "apps/onebite",
+      "link": true
     },
     "node_modules/onetime": {
       "version": "5.1.2",


### PR DESCRIPTION
## 📝 작업 내용
### 문제
- `layout.tsx`는 리렌더링되지 않기 때문에 searchParams와 같은 동적인 값에 접근할 수 없고, 페이지 전환 시 애니메이션 효과를 적용할 수 없다.
- 페이지 이동 시 자연스럽고 방향성 있는 전환 효과 필요

### 액션
- `template.tsx`를 활용하여 라우팅 시마다 리렌더링되도록 구조 변경
- framer-motion을 사용해 페이지 진입/이탈 시 애니메이션 적용
- `window.history.length`를 기준으로 앞으로/뒤로 이동 방향 구분
- 커스텀 Link 컴포넌트와 router 확장을 통해 방향 정보 전달

## 🎉 결과

https://github.com/user-attachments/assets/65db223b-cffe-41e9-8a7d-743488bce0a8


- 페이지 이동 시 자연스러운 전환 애니메이션 구현 완료
- 앞/뒤 이동에 따른 애니메이션 방향 분기 가능

## 🧠 추가 고려사항
- 페이지 캐시 처리
- 캐시된 페이지 언마운트 시 메모리 전리를 통한 최적화 필요
- 방향 정보를 더 안정적으로 전달하기 위한 상태 관리 방식 검토 필요